### PR TITLE
allow usage of ScopedCssBaseline to avoid *global* CSS competition

### DIFF
--- a/packages/ui-sdk/src/FormantProvider.tsx
+++ b/packages/ui-sdk/src/FormantProvider.tsx
@@ -2,14 +2,17 @@ import * as React from "react";
 
 import ThemeProvider from "@mui/material/styles/ThemeProvider";
 import CssBaseline from "@mui/material/CssBaseline";
+import ScopedCssBaseline from "@mui/material/ScopedCssBaseline";
 import { darkTheme, lightTheme, defaultTheme } from "./theme";
 import { createTheme } from "@mui/material/styles";
 import { useContext } from "react";
 import { useConfiguration } from "./hooks";
+
 interface IFormantProviderProps {
   theme?: "dark" | "light";
   children: React.ReactNode;
   parseConfiguration?: boolean;
+  scoped?: boolean;
 }
 
 interface UseFormant {
@@ -26,6 +29,7 @@ export function FormantProvider({
   theme,
   children,
   parseConfiguration,
+  scoped = false,
 }: IFormantProviderProps) {
   const configuration = useConfiguration({ parse: !!parseConfiguration });
   const muiTheme = createTheme(
@@ -35,13 +39,15 @@ export function FormantProvider({
   // We can put global caches for data here
   const useFormant = { configuration };
 
+  const Baseline = scoped ? ScopedCssBaseline : CssBaseline;
+
   return (
     <ThemeProvider theme={muiTheme}>
-      <CssBaseline>
+      <Baseline>
         <FormantContext.Provider value={useFormant}>
           {children}
         </FormantContext.Provider>
-      </CssBaseline>
+      </Baseline>
     </ThemeProvider>
   );
 }


### PR DESCRIPTION
Allow more _scoped_ CSS injection for `<FormantProvider>`. This helps `ui-docs` have a better/more fine-grained control over CSS injection and avoids conflicts with intrinsic styling with the ladle UI elements.

It might be worth considering _always_ using `<ScopedCssBaseline>`, to avoid overriding _external third-party_ styles on the embedding page, and _only_ reset CSS _inside_ of the `<FormantProvider>` scope.

### Extended Notes/Thoughts

- I didn't fully grasp until the end of last week that this actually _already uses_ [`emotion`](https://emotion.sh/docs/introduction); which means in `@formant/frontend` _already_ has _three_ separate CSS generators/competing in slightly different ways. But I think thats another tick towards _retiring both_ the legacy-SCSS stack _and_ the `styled-components` stack in favor of `@emotion/styled` and `@emotion/react` 
- `@formant/ui-sdk` is pretty out of date back in `@formant/frontend`; its presently using `0.0.17` from 2022-04. Will need to get that upgraded and hope there aren't any conflicts/changes that affect things over there.