### PR TITLE
Ping should still be returned when the connection to signaling is lost

### DIFF
--- a/packages/data-sdk/src/Device.ts
+++ b/packages/data-sdk/src/Device.ts
@@ -223,7 +223,7 @@ export class Device extends EventEmitter implements IRealtimeDevice {
   }
 
   async startRealtimeConnection(sessionType?: number) {
-    if (!this.rtcClient) {
+    if (!this.rtcClient || this.connectionMonitorInterval === undefined) {
       let rtcClient;
 
       if (rtcClientVersion === "1") {
@@ -575,7 +575,6 @@ export class Device extends EventEmitter implements IRealtimeDevice {
     if (this.rtcClient) {
       this.stopConnectionMonitoring();
       await this.rtcClient.disconnect(this.id);
-      this.rtcClient = undefined;
     } else {
       throw new Error(`Realtime connection hasn't been started for ${this.id}`);
     }


### PR DESCRIPTION
Although the signaling connectivity may have failed, we need to keep `rtcClient` around for fetching RTC specific metrics. It will be replaced with a fresh rtcClient when the connection is restarted.