### PR TITLE
Reenforce type constraints on aggregateByDateFunctions

### DIFF
--- a/packages/data-sdk/src/model/AggregateLevel.ts
+++ b/packages/data-sdk/src/model/AggregateLevel.ts
@@ -3,13 +3,6 @@ export type AggregateLevel =
   | "month"
   | "week"
   | "day"
-  | "12 hours"
-  | "4 hours"
   | "hour"
-  | "30 minutes"
-  | "5 minutes"
   | "minute"
-  | "30 seconds"
-  | "5 seconds"
-  | "second"
   | "quarter";

--- a/packages/data-sdk/src/utils/aggregateFunctionUtils.ts
+++ b/packages/data-sdk/src/utils/aggregateFunctionUtils.ts
@@ -1,5 +1,6 @@
 import { INumericAggregate } from "../model/INumericAggregate";
 import * as dateFns from "date-fns";
+import { AggregateLevel } from "../model/AggregateLevel";
 
 export const vailableAggregationIntervals = [
   "day",
@@ -71,7 +72,18 @@ export const aggregateFunctionMap = {
   count: getCount,
 };
 
-export const aggregateByDateFunctions: any = {
+interface IAggregateFunctions {
+  interval: (interval: dateFns.Interval) => Date[];
+  start: (date: Date | number) => Date;
+  end: (date: Date | number) => Date;
+  sub: (date: Date | number, amount: number) => Date;
+  get: (date: Date | number) => number;
+}
+
+export const aggregateByDateFunctions: Record<
+  AggregateLevel,
+  IAggregateFunctions
+> = {
   day: {
     interval: dateFns.eachDayOfInterval,
     start: dateFns.startOfDay,
@@ -124,6 +136,10 @@ export const aggregateByDateFunctions: any = {
 };
 
 export const formatTimeFrameText = (start: string, end: string) =>
+  // FIXME this doesn't work for *a lot* locales, other than en-US
+  // en-GB: 'dd/mm/YYYY'
+  // ja-jp: 'YYYY/mm/dd'
+  // bg-BG: 'dd.mm.YYYY'
   start.split("/")[0] +
   "/" +
   start.split("/")[1] +


### PR DESCRIPTION
- Constrain AggregateLevel to only supported constants