### PR TITLE
remove return from startRealTimeConnection

### DIFF
--- a/packages/data-sdk/src/AppRtcClientPools.ts
+++ b/packages/data-sdk/src/AppRtcClientPools.ts
@@ -1,4 +1,9 @@
-import { RtcClient, SignalingPromiseClient } from "@formant/realtime-sdk";
+import {
+  RtcClient,
+  RtcClientV1,
+  RtcSignalingClient,
+  SignalingPromiseClient,
+} from "@formant/realtime-sdk";
 import { RtcClientPool } from "./utils/RtcClientPool";
 import { FORMANT_API_URL } from "./config";
 import { Authentication } from "./Authentication";
@@ -66,6 +71,31 @@ export const AppRtcClientPools = {
 } as const;
 
 export const defaultRtcClientPool = EnumRtcClientPools[SessionType.TELEOP];
+
+export const v1RtcClientPool = new RtcClientPool({
+  ttlMs: 2_500,
+  createClient: (receiveFn) =>
+    new RtcClientV1({
+      signalingClient: new RtcSignalingClient(
+        FORMANT_API_URL + "/v1/signaling"
+      ),
+      getToken,
+      receive: receiveFn,
+    }),
+});
+
+export const getRtcClientPool = (options: {
+  version: string;
+  sessionType?: SessionType;
+}) => {
+  const { version, sessionType } = options;
+
+  if (version === "1") {
+    return v1RtcClientPool;
+  }
+
+  return sessionType ? AppRtcClientPools[sessionType] : defaultRtcClientPool;
+};
 
 export function debug() {
   console.group("RtcClientPool Sizes");

--- a/packages/data-sdk/src/Device.ts
+++ b/packages/data-sdk/src/Device.ts
@@ -305,13 +305,10 @@ export class Device extends EventEmitter implements IRealtimeDevice {
             this.initConnectionMonitoring();
             this.rtcClient = rtcClient;
             this.emit("connect");
-            return;
+            i = 100;
           }
           await delay(100);
         }
-        throw new Error(
-          "A session was created, but the connection could not be established, possibly due to network issues or misconfigured settings."
-        );
       } else {
         throw new Error(`Unable to establish a connection at this time.`);
       }

--- a/packages/data-sdk/src/Device.ts
+++ b/packages/data-sdk/src/Device.ts
@@ -5,13 +5,12 @@ import {
   IRtcStreamPayload,
   RtcClient,
   RtcClientV1,
-  RtcSignalingClient,
   IRtcClientConfiguration,
 } from "@formant/realtime-sdk";
 import { RtcStreamType } from "@formant/realtime-sdk/dist/model/RtcStreamType";
 import { IRtcPeer } from "@formant/realtime-sdk/dist/model/IRtcPeer";
 
-import { AppRtcClientPools, defaultRtcClientPool } from "./AppRtcClientPools";
+import { getRtcClientPool } from "./AppRtcClientPools";
 import { Authentication } from "./Authentication";
 import { DataChannel } from "./DataChannel";
 import { CaptureStream } from "./CaptureStream";
@@ -35,13 +34,9 @@ import { AggregateLevel } from "./model/AggregateLevel";
 import { EventType } from "./model/EventType";
 import { IShare } from "./model/IShare";
 import { ITags } from "./model/ITags";
-import { isRtcPeer } from "./utils";
+import { isRtcPeer, getRtcClientVersion } from "./utils";
 
 type SessionType = IRtcClientConfiguration["sessionType"];
-
-// get query param for "rtc_client"
-const urlParams = new URLSearchParams(window.location.search);
-const rtcClientVersion = urlParams.get("rtc_client");
 
 export interface ConfigurationDocument {
   tags: ITags;
@@ -265,23 +260,11 @@ export class Device extends EventEmitter implements IRealtimeDevice {
       );
     }
 
-    let rtcClient;
-
-    if (rtcClientVersion === "1") {
-      rtcClient = new RtcClientV1({
-        signalingClient: new RtcSignalingClient(
-          FORMANT_API_URL + "/v1/signaling"
-        ),
-        getToken: async () =>
-          defined(Authentication.token, "Realtime when user isn't authorized"),
-        receive: this.handleMessage,
-      });
-    } else {
-      const pool = sessionType
-        ? AppRtcClientPools[sessionType]
-        : defaultRtcClientPool;
-      rtcClient = pool.get(this.handleMessage);
-    }
+    const pool = getRtcClientPool({
+      version: getRtcClientVersion() ?? "2",
+      sessionType,
+    });
+    const rtcClient = pool.get(this.handleMessage);
 
     if ("isReady" in rtcClient) {
       while (!rtcClient.isReady()) {
@@ -779,11 +762,12 @@ export class Device extends EventEmitter implements IRealtimeDevice {
     channelName: string,
     rtcConfig?: RTCDataChannelInit
   ): Promise<DataChannel> {
-    if (rtcClientVersion === "1") {
+    if (getRtcClientVersion() === "1") {
       throw new Error(
         "createCustomDataChannel is not supported in rtcClientVersion 1"
       );
     }
+
     const client = defined(
       this.rtcClient,
       "Realtime connection has not been started"

--- a/packages/data-sdk/src/Device.ts
+++ b/packages/data-sdk/src/Device.ts
@@ -251,71 +251,93 @@ export class Device extends EventEmitter implements IRealtimeDevice {
    */
 
   async startRealtimeConnection(sessionType?: SessionType): Promise<void> {
-    if (!this.rtcClient || this.connectionMonitorInterval === undefined) {
-      if (this.rtcClient) {
-        console.error(
-          "overwriting existing rtcClient due to missing connectionMonitorInterval"
-        );
-      }
+    console.debug(`${new Date().toISOString()} :: Connection start requested`);
 
-      let rtcClient;
-
-      if (rtcClientVersion === "1") {
-        rtcClient = new RtcClientV1({
-          signalingClient: new RtcSignalingClient(
-            FORMANT_API_URL + "/v1/signaling"
-          ),
-          getToken: async () =>
-            defined(
-              Authentication.token,
-              "Realtime when user isn't authorized"
-            ),
-          receive: this.handleMessage,
-        });
-      } else {
-        const pool = sessionType
-          ? AppRtcClientPools[sessionType]
-          : defaultRtcClientPool;
-        rtcClient = pool.get(this.handleMessage);
-      }
-
-      if ("isReady" in rtcClient) {
-        while (!rtcClient.isReady()) {
-          await delay(100);
-        }
-      }
-
-      // WebRTC requires a signaling phase when forming a new connection.
-
-      this.remoteDevicePeerId = await this.getRemoteDevicePeerId(rtcClient);
-
-      const sessionId = await this.createSession(rtcClient);
-
-      // Wait for the signaling process to complete...
-      if (!!sessionId) {
-        const retries = 100;
-        for (let i = 0; i < retries; i++) {
-          const connectionCompleted =
-            rtcClient.getConnectionStatus(this.remoteDevicePeerId) ===
-            "connected";
-          if (connectionCompleted) {
-            console.debug(
-              `${new Date().toISOString()} :: Connection completed after ${i} retries`
-            );
-            this.initConnectionMonitoring();
-            this.rtcClient = rtcClient;
-            this.emit("connect");
-            i = 100;
-          }
-          await delay(100);
-        }
-      } else {
-        throw new Error(`Unable to establish a connection at this time.`);
-      }
-    } else {
+    if (this.rtcClient && this.connectionMonitorInterval !== undefined) {
       throw new Error(
         `Already created realtime connection to device ${this.id}`
       );
+    }
+
+    if (this.rtcClient) {
+      console.warn(
+        "overwriting existing rtcClient due to missing connectionMonitorInterval"
+      );
+    }
+
+    let rtcClient;
+
+    if (rtcClientVersion === "1") {
+      rtcClient = new RtcClientV1({
+        signalingClient: new RtcSignalingClient(
+          FORMANT_API_URL + "/v1/signaling"
+        ),
+        getToken: async () =>
+          defined(Authentication.token, "Realtime when user isn't authorized"),
+        receive: this.handleMessage,
+      });
+    } else {
+      const pool = sessionType
+        ? AppRtcClientPools[sessionType]
+        : defaultRtcClientPool;
+      rtcClient = pool.get(this.handleMessage);
+    }
+
+    if ("isReady" in rtcClient) {
+      while (!rtcClient.isReady()) {
+        await delay(100);
+      }
+    }
+
+    // WebRTC requires a signaling phase when forming a new connection.
+
+    this.remoteDevicePeerId = await this.getRemoteDevicePeerId(rtcClient);
+
+    const sessionId = await this.createSession(rtcClient);
+
+    // Wait for the signaling process to complete...
+    if (!sessionId) {
+      try {
+        // cleanup
+        this.remoteDevicePeerId = null;
+        await rtcClient.shutdown();
+      } catch (err) {
+        console.error("rtcClient cannot shutdown", { err });
+      }
+
+      throw new Error(`Unable to establish a connection at this time.`);
+    }
+
+    const retries = 100;
+    for (let i = 0; i < retries; i++) {
+      const connectionCompleted =
+        rtcClient.getConnectionStatus(this.remoteDevicePeerId) === "connected";
+
+      if (!connectionCompleted) {
+        await delay(100);
+        continue;
+      }
+
+      console.debug(
+        `${new Date().toISOString()} :: Connection completed after ${i} retries`
+      );
+      this.initConnectionMonitoring();
+      this.rtcClient = rtcClient;
+      this.emit("connect");
+      return;
+    }
+
+    console.error(
+      "Connection failed: A session was created, but the connection could not be established, " +
+        "possibly due to network issues or misconfigured settings."
+    );
+
+    try {
+      // cleanup
+      this.remoteDevicePeerId = null;
+      await rtcClient.shutdown();
+    } catch (err) {
+      console.error("rtcClient cannot shutdown", { err });
     }
   }
 
@@ -333,21 +355,21 @@ export class Device extends EventEmitter implements IRealtimeDevice {
     return devicePeer.id;
   }
 
-  private async createSession(rtcClient: RtcClient | RtcClientV1) {
+  private async createSession(
+    rtcClient: RtcClient | RtcClientV1
+  ): Promise<string | null> {
     // We can connect our real-time communication client to device peers by their ID
     const tries = 3;
     if (this.remoteDevicePeerId) {
       for (let i = 0; i < tries; i++) {
-        const connectionId = await (rtcClient as RtcClient).connect(
-          this.remoteDevicePeerId
-        );
+        const connectionId = await rtcClient.connect(this.remoteDevicePeerId);
         if (!!connectionId) {
           return connectionId;
         }
         delay(100);
       }
     }
-    return;
+    return null;
   }
 
   private initConnectionMonitoring() {

--- a/packages/data-sdk/src/utils/index.ts
+++ b/packages/data-sdk/src/utils/index.ts
@@ -3,3 +3,4 @@ export * from "./numericAggregateUtils";
 export * from "./timeout";
 export * from "./serializeHash";
 export * from "./isRtcPeer";
+export { getRtcClientVersion } from "./rtcClientVersion";

--- a/packages/data-sdk/src/utils/rtcClientVersion.ts
+++ b/packages/data-sdk/src/utils/rtcClientVersion.ts
@@ -1,0 +1,14 @@
+let version: string | null | undefined;
+
+export function overrideRtcClientVersion(newVersion: string | null) {
+  version = newVersion;
+}
+
+export function getRtcClientVersion(): string | null {
+  if (version === undefined) {
+    // get query param for "rtc_client"
+    const urlParams = new URLSearchParams(window.location.search);
+    version = urlParams.get("rtc_client");
+  }
+  return version;
+}


### PR DESCRIPTION
Rethinking the `startRealtimeConnection()` implementation…

- flattening the nesting depth by inverting some of the if's and _throwing_ early to _proactively_ eject
- perform cleanup on `!sessionId` case and when `retries` are _exhaused_. This prevents `rtcClient` from being _undisposed and orphaned_ and a _stale_ `remoteDevicePeerId` left over on `this`
- extend `RtcClientPool` to also _support both_. Doesn't seem to be a reason why this can't just _work_ with both/either.
- simplify down the `rtcClientVersion` branch to just select the approprate pool and allocate.
- extracting out `getRtcClientVersion` into helper method with _override_ for future testing.