### PR TITLE
Rethinking the `startRealtimeConnection()` implementation

### DIFF
--- a/packages/data-sdk/src/AppRtcClientPools.ts
+++ b/packages/data-sdk/src/AppRtcClientPools.ts
@@ -4,59 +4,54 @@ import {
   RtcSignalingClient,
   SignalingPromiseClient,
 } from "@formant/realtime-sdk";
+
+import { SessionType, SessionTypes } from "./model/SessionType";
 import { RtcClientPool } from "./utils/RtcClientPool";
 import { FORMANT_API_URL } from "./config";
 import { Authentication } from "./Authentication";
 import { defined } from "../../common/defined";
 
-export enum SessionType {
-  UNKNOWN = 0,
-  TELEOP = 1,
-  PORT_FORWARD = 2,
-  OBSERVE = 3,
-}
-
 const getToken = async () =>
   defined(Authentication.token, "Realtime when user isn't authorized");
 
 const EnumRtcClientPools = {
-  [SessionType.UNKNOWN]: new RtcClientPool({
+  [SessionTypes.UNKNOWN]: new RtcClientPool({
     ttlMs: 2_500,
     createClient: (receiveFn) =>
       new RtcClient({
         signalingClient: new SignalingPromiseClient(FORMANT_API_URL),
         getToken,
-        sessionType: SessionType.UNKNOWN,
+        sessionType: SessionTypes.UNKNOWN,
         receive: receiveFn,
       }),
   }),
-  [SessionType.TELEOP]: new RtcClientPool({
+  [SessionTypes.TELEOP]: new RtcClientPool({
     ttlMs: 2_500,
     createClient: (receiveFn) =>
       new RtcClient({
         signalingClient: new SignalingPromiseClient(FORMANT_API_URL),
         getToken,
-        sessionType: SessionType.TELEOP,
+        sessionType: SessionTypes.TELEOP,
         receive: receiveFn,
       }),
   }),
-  [SessionType.PORT_FORWARD]: new RtcClientPool({
+  [SessionTypes.PORT_FORWARD]: new RtcClientPool({
     ttlMs: 2_500,
     createClient: (receiveFn) =>
       new RtcClient({
         signalingClient: new SignalingPromiseClient(FORMANT_API_URL),
         getToken,
-        sessionType: SessionType.PORT_FORWARD,
+        sessionType: SessionTypes.PORT_FORWARD,
         receive: receiveFn,
       }),
   }),
-  [SessionType.OBSERVE]: new RtcClientPool({
+  [SessionTypes.OBSERVE]: new RtcClientPool({
     ttlMs: 2_500,
     createClient: (receiveFn) =>
       new RtcClient({
         signalingClient: new SignalingPromiseClient(FORMANT_API_URL),
         getToken,
-        sessionType: SessionType.OBSERVE,
+        sessionType: SessionTypes.OBSERVE,
         receive: receiveFn,
       }),
   }),
@@ -64,13 +59,13 @@ const EnumRtcClientPools = {
 
 export const AppRtcClientPools = {
   ...EnumRtcClientPools,
-  unknown: EnumRtcClientPools[SessionType.UNKNOWN],
-  teleop: EnumRtcClientPools[SessionType.TELEOP],
-  portForward: EnumRtcClientPools[SessionType.PORT_FORWARD],
-  observe: EnumRtcClientPools[SessionType.OBSERVE],
+  unknown: EnumRtcClientPools[SessionTypes.UNKNOWN],
+  teleop: EnumRtcClientPools[SessionTypes.TELEOP],
+  portForward: EnumRtcClientPools[SessionTypes.PORT_FORWARD],
+  observe: EnumRtcClientPools[SessionTypes.OBSERVE],
 } as const;
 
-export const defaultRtcClientPool = EnumRtcClientPools[SessionType.TELEOP];
+export const defaultRtcClientPool = EnumRtcClientPools[SessionTypes.TELEOP];
 
 export const v1RtcClientPool = new RtcClientPool({
   ttlMs: 2_500,

--- a/packages/data-sdk/src/AppRtcClientPools.ts
+++ b/packages/data-sdk/src/AppRtcClientPools.ts
@@ -1,4 +1,9 @@
-import { RtcClient, SignalingPromiseClient } from "@formant/realtime-sdk";
+import {
+  RtcClient,
+  RtcClientV1,
+  RtcSignalingClient,
+  SignalingPromiseClient,
+} from "@formant/realtime-sdk";
 import { RtcClientPool } from "./utils/RtcClientPool";
 import { FORMANT_API_URL } from "./config";
 import { Authentication } from "./Authentication";
@@ -66,6 +71,31 @@ export const AppRtcClientPools = {
 } as const;
 
 export const defaultRtcClientPool = EnumRtcClientPools[SessionType.TELEOP];
+
+export const v1RtcClientPool = new RtcClientPool({
+  ttlMs: 2_500,
+  createClient: (receiveFn) =>
+    new RtcClientV1({
+      signalingClient: new RtcSignalingClient(
+        FORMANT_API_URL + "/v1/signaling"
+      ),
+      getToken,
+      receive: receiveFn,
+    }),
+});
+
+export const getRtcClientPool = (options: {
+  version: string;
+  sessionType?: SessionType;
+}) => {
+  const { version, sessionType } = options;
+
+  if (version === "1") {
+    return v1RtcClientPool;
+  }
+
+  return sessionType ? AppRtcClientPools[sessionType] : defaultRtcClientPool;
+};
 
 export function debug() {
   console.group("RtcClientPool Sizes");

--- a/packages/data-sdk/src/Device.ts
+++ b/packages/data-sdk/src/Device.ts
@@ -305,13 +305,10 @@ export class Device extends EventEmitter implements IRealtimeDevice {
             this.initConnectionMonitoring();
             this.rtcClient = rtcClient;
             this.emit("connect");
-            return;
+            i = 100;
           }
           await delay(100);
         }
-        throw new Error(
-          "A session was created, but the connection could not be established, possibly due to network issues or misconfigured settings."
-        );
       } else {
         throw new Error(`Unable to establish a connection at this time.`);
       }

--- a/packages/data-sdk/src/main.ts
+++ b/packages/data-sdk/src/main.ts
@@ -145,6 +145,7 @@ export * from "./model/VideoMimeType";
 export * from "./model/IDeviceQuery";
 export * from "./model/IAnnotationQuery";
 export * from "./model/IStream";
+export { SessionTypeConstants as SessionType } from "./model/SessionType";
 export type {
   IRtcSendConfiguration,
   IRtcStreamMessage,

--- a/packages/data-sdk/src/model/SessionType.ts
+++ b/packages/data-sdk/src/model/SessionType.ts
@@ -1,0 +1,25 @@
+import { IRtcClientConfiguration } from "@formant/realtime-sdk";
+
+export type SessionType = NonNullable<IRtcClientConfiguration["sessionType"]>;
+
+export const SessionTypes = {
+  UNKNOWN: 0,
+  TELEOP: 1,
+  PORT_FORWARD: 2,
+  OBSERVE: 3,
+} as const satisfies Record<string, SessionType>;
+
+// For backwards-compatibility
+export const SessionTypeConstants = {
+  ...SessionTypes,
+
+  Unknown: SessionTypes.UNKNOWN,
+  Teleop: SessionTypes.TELEOP,
+  PortForward: SessionTypes.PORT_FORWARD,
+  Observe: SessionTypes.OBSERVE,
+
+  unknown: SessionTypes.UNKNOWN,
+  teleop: SessionTypes.TELEOP,
+  portForward: SessionTypes.PORT_FORWARD,
+  observe: SessionTypes.OBSERVE,
+} as const satisfies Record<string, SessionType>;

--- a/packages/data-sdk/src/utils/index.ts
+++ b/packages/data-sdk/src/utils/index.ts
@@ -3,3 +3,4 @@ export * from "./numericAggregateUtils";
 export * from "./timeout";
 export * from "./serializeHash";
 export * from "./isRtcPeer";
+export { getRtcClientVersion } from "./rtcClientVersion";

--- a/packages/data-sdk/src/utils/isRtcPeer.ts
+++ b/packages/data-sdk/src/utils/isRtcPeer.ts
@@ -1,4 +1,6 @@
 import { IRtcPeer } from "@formant/realtime-sdk/dist/model/IRtcPeer";
 
-export const isRtcPeer = (_: IRtcPeer | any): _ is IRtcPeer =>
-  _.capabilities !== undefined && _.capabilitySet !== undefined;
+export const isRtcPeer = (peer: IRtcPeer | undefined): peer is IRtcPeer =>
+  peer !== undefined &&
+  peer.capabilities !== undefined &&
+  peer.capabilitySet !== undefined;

--- a/packages/data-sdk/src/utils/rtcClientVersion.ts
+++ b/packages/data-sdk/src/utils/rtcClientVersion.ts
@@ -1,0 +1,14 @@
+let version: string | null | undefined;
+
+export function overrideRtcClientVersion(newVersion: string | null) {
+  version = newVersion;
+}
+
+export function getRtcClientVersion(): string | null {
+  if (version === undefined) {
+    // get query param for "rtc_client"
+    const urlParams = new URLSearchParams(window.location.search);
+    version = urlParams.get("rtc_client");
+  }
+  return version;
+}


### PR DESCRIPTION
- flattening the nesting depth by inverting some of the if's and _throwing_ early to _proactively_ eject
- perform cleanup on `!sessionId` case and when `retries` are _exhaused_. This prevents `rtcClient` from being _undisposed and orphaned_ and a _stale_ `remoteDevicePeerId` left over on `this`
- reworking `startRealtimeConnection()` to support deeper configuration options. 
- extend `RtcClientPool` to also _support both_. Doesn't seem to be a reason why this can't just _work_ with both/either.
- simplify down the `rtcClientVersion` branch to just select the approprate pool and allocate.
- extracting out `getRtcClientVersion` into helper method with _override_ for future testing.

Example:
```ts
try {
  await Device.startRealtimeConnection({ 
    sessionType: SessionType.Observe,
    deadlineMs: 30_000, 
    maxConnectRetries: Infinity 
  });
} catch (err) {
  console.error("Failed to connect!", err);
}
```