### PR TITLE
add time to get date and remove listener only when the right message …

### DIFF
--- a/packages/data-sdk/src/App.ts
+++ b/packages/data-sdk/src/App.ts
@@ -13,7 +13,7 @@ export interface IDevice {
 }
 
 export type AppMessage =
-  | { type: "request_date"; minTime?: Date; maxTime?: Date }
+  | { type: "request_date"; minTime?: Date; maxTime?: Date; time?: Date }
   | { type: "go_to_time"; time: number }
   | {
       type: "prompt";
@@ -370,19 +370,20 @@ export class App {
     });
   }
 
-  static async getDate(minTime?: Date, maxTime?: Date) {
+  static async getDate(time?: Date, minTime?: Date, maxTime?: Date) {
     return new Promise((resolve) => {
       this.sendAppMessage({
         type: "request_date",
         minTime,
         maxTime,
+        time,
       });
       const handler = (event: any) => {
         const msg = event.data as EmbeddedAppMessage;
         if (msg.type === "date_response") {
+          window.removeEventListener("message", handler);
           resolve(msg.data);
         }
-        window.removeEventListener("message", handler);
       };
       window.addEventListener("message", handler);
     });


### PR DESCRIPTION
1. Add time to get data function so when the calendar opens is on the expected date
2. Remove the listener only when we get the `date` message. Other types of messages were removing the listener and the data was getting lost. 