### PR TITLE
Ensure Realtime* types get exported from BaseDevice

### DIFF
--- a/packages/data-sdk/package.json
+++ b/packages/data-sdk/package.json
@@ -26,7 +26,7 @@
   },
   "version": "1.3.0",
   "scripts": {
-    "preversion": "npm run test && tsc --project ./configs/tsconfig.type-check.json",
+    "preversion": "npm run verify",
     "postversion": "make",
     "dev": "vite --port 5173",
     "build": "tsc -p ./configs/tsconfig.demo.json && vite build",
@@ -37,6 +37,8 @@
     "prettier:check": "prettier --check src/",
     "prettier:write": "prettier --write src/",
     "types": "tsc --project ./configs/tsconfig.types.json",
+    "types:check": "tsc --project ./configs/tsconfig.type-check.json",
+    "verify": "concurrently --kill-others-on-fail npm:test:* npm:prettier:check npm:types:check",
     "docs": "typedoc src/main.ts --theme default --out ../../docs/data-sdk/"
   },
   "devDependencies": {

--- a/packages/data-sdk/src/main.ts
+++ b/packages/data-sdk/src/main.ts
@@ -33,11 +33,17 @@ export type {
 } from "./App";
 export type { TelemetryResult } from "./Fleet";
 export type {
+  Command,
+  ConfigurationDocument,
+  IAdapterConfiguration,
+  IJointState,
+  IStartRealtimeConnectionOptions,
   RealtimeAudioStream,
   RealtimeDataStream,
   RealtimeListener,
   RealtimeMessage,
   RealtimeVideoStream,
+  TelemetryStream,
 } from "./BaseDevice";
 export type {
   DataChannelBinaryListener,

--- a/packages/data-sdk/src/main.ts
+++ b/packages/data-sdk/src/main.ts
@@ -1,30 +1,63 @@
 import { Buffer } from "buffer";
 window.Buffer = Buffer;
-export * from "./Fleet";
-export * from "./Authentication";
-export * from "./Device";
-export * from "./PeerDevice";
-export * from "./DataChannel";
-export * from "./CaptureStream";
-export * from "./Manipulator";
-export * from "./RequestDataChannel";
-export * from "./App";
-export * from "./KeyValue";
-export * from "./utils";
-export * from "./AudioPlayer";
-export * from "./Account";
-export * from "./Role";
-export * from "./User";
 
+export { App } from "./App";
+export { Fleet } from "./Fleet";
+export { Authentication } from "./Authentication";
+export { Device } from "./Device";
+export { PeerDevice } from "./PeerDevice";
+export { DataChannel } from "./DataChannel";
+export { CaptureStream } from "./CaptureStream";
+export { Manipulator } from "./Manipulator";
+export {
+  BinaryRequestDataChannel,
+  TextRequestDataChannel,
+} from "./RequestDataChannel";
+export { KeyValue } from "./KeyValue";
+export { AudioPlayer } from "./AudioPlayer";
+export { Account } from "./Account";
+export { Role } from "./Role";
+export { User } from "./User";
+
+// Re-exporting core types
+export type {
+  AppMessage,
+  DataPoint,
+  EmbeddedAppMessage,
+  IDevice,
+  ModuleConfigurationMessage,
+  ModuleData,
+  QueryRange,
+  Stream,
+  StreamData,
+} from "./App";
+export type { TelemetryResult } from "./Fleet";
+export type {
+  RealtimeAudioStream,
+  RealtimeDataStream,
+  RealtimeListener,
+  RealtimeMessage,
+  RealtimeVideoStream,
+} from "./BaseDevice";
+export type {
+  DataChannelBinaryListener,
+  DataChannelErrorListener,
+  DataChannelListener,
+  DataChannelStringListener,
+} from "./DataChannel";
+export type { CaptureSession } from "./CaptureStream";
+export type { RealtimeManipulatorConfig } from "./Manipulator";
+
+// Application Initialization
 import { App } from "./App";
 import { Fleet } from "./Fleet";
 import { Authentication } from "./Authentication";
 
 try {
   const urlParams =
-  (typeof window !== "undefined" && window.location)
-    ? new URLSearchParams(window.location.search)
-    : new URLSearchParams("");
+    typeof window !== "undefined" && window.location
+      ? new URLSearchParams(window.location.search)
+      : new URLSearchParams("");
 
   const urlDevice = urlParams.get("device");
   if (urlDevice) {


### PR DESCRIPTION
When several interfaces/types moved from `Device.ts` to `BaseDevice.ts` with #99, they are _no longer_ exported from `main.ts`, because `BaseDevice` is not _re-exported_ from `main.ts`. This is _problematic_ for `@formant/universe-connector` which relies on these shapes. However, due to the `export * from "./Device"` doesn't make that _obvious_ that those interfaces are _part of the public contract_. This PR _explicitly_ exports all the members from top-level exports.

Other changes:
- ensure that prettier gets checked during the _pre-version_ phase.