### PR TITLE
Use base64 package for decoding

### DIFF
--- a/packages/common/stringToArrayBuffer.ts
+++ b/packages/common/stringToArrayBuffer.ts
@@ -1,3 +1,0 @@
-export function stringToArrayBuffer(input: string): Uint8Array {
-  return Uint8Array.from(atob(input), (_) => _.charCodeAt(0));
-}

--- a/packages/data-sdk/package-lock.json
+++ b/packages/data-sdk/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.5.4",
       "license": "MIT",
       "dependencies": {
+        "base-64": "^1.0.0",
         "base64-js": "^1.5.1",
         "date-fns": "^2.30.0",
         "eventemitter3": "^5.0.1",
@@ -306,6 +307,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/base-64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
+      "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg=="
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -2585,6 +2591,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "base-64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
+      "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg=="
     },
     "base64-js": {
       "version": "1.5.1",

--- a/packages/data-sdk/package.json
+++ b/packages/data-sdk/package.json
@@ -61,6 +61,7 @@
   },
   "types": "./dist/types/data-sdk/src/main.d.ts",
   "dependencies": {
+    "base-64": "^1.0.0",
     "base64-js": "^1.5.1",
     "date-fns": "^2.30.0",
     "eventemitter3": "^5.0.1",

--- a/packages/data-sdk/src/AudioPlayer.ts
+++ b/packages/data-sdk/src/AudioPlayer.ts
@@ -1,6 +1,6 @@
 import { IRtcStreamMessage } from "@formant/realtime-sdk";
 import { Device } from "./devices/Device";
-import { stringToArrayBuffer } from "../../common/stringToArrayBuffer";
+import { stringToArrayBuffer } from "./utils/stringToArrayBuffer";
 import { fork } from "../../common/fork";
 import { browser } from "../../common/browser";
 import { RealtimeDataStream, RealtimeMessage } from "./devices/device.types";

--- a/packages/data-sdk/src/devices/PeerDevice.ts
+++ b/packages/data-sdk/src/devices/PeerDevice.ts
@@ -106,7 +106,7 @@ export class PeerDevice extends BaseDevice {
     return cfg.configuration.document;
   }
 
-  async startRealtimeConnection(sessionType?: number) {
+  async startRealtimeConnection(sessionType?: number): Promise<void> {
     console.debug(`${new Date().toISOString()} :: Connection start requested`);
 
     if (this.rtcClient && this.connectionMonitorInterval !== undefined) {

--- a/packages/data-sdk/src/stores/AuthenticationStore.ts
+++ b/packages/data-sdk/src/stores/AuthenticationStore.ts
@@ -1,3 +1,5 @@
+import { decode } from 'base-64'
+
 import {
   IAuthentication,
   IAuthenticationStore,
@@ -102,7 +104,7 @@ export class AuthenticationStore implements IAuthenticationStore {
   }
 
   async loginWithToken(token: string, refreshToken?: string) {
-    const tokenData = JSON.parse(atob(token.split(".")[1]));
+    const tokenData = JSON.parse(decode(token.split(".")[1]));
     try {
       let userId: string | undefined;
       this._isShareToken =

--- a/packages/data-sdk/src/utils/stringToArrayBuffer.ts
+++ b/packages/data-sdk/src/utils/stringToArrayBuffer.ts
@@ -1,0 +1,5 @@
+import { decode } from 'base-64'
+
+export function stringToArrayBuffer(input: string): Uint8Array {
+  return Uint8Array.from(decode(input), (_) => _.charCodeAt(0));
+}

--- a/packages/package-lock.json
+++ b/packages/package-lock.json
@@ -1,0 +1,26 @@
+{
+  "name": "packages",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "@types/base-64": "^1.0.0"
+      }
+    },
+    "node_modules/@types/base-64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/base-64/-/base-64-1.0.0.tgz",
+      "integrity": "sha512-AvCJx/HrfYHmOQRFdVvgKMplXfzTUizmh0tz9GFTpDePWgCY4uoKll84zKlaRoeiYiCr7c9ZnqSTzkl0BUVD6g==",
+      "dev": true
+    }
+  },
+  "dependencies": {
+    "@types/base-64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/base-64/-/base-64-1.0.0.tgz",
+      "integrity": "sha512-AvCJx/HrfYHmOQRFdVvgKMplXfzTUizmh0tz9GFTpDePWgCY4uoKll84zKlaRoeiYiCr7c9ZnqSTzkl0BUVD6g==",
+      "dev": true
+    }
+  }
+}

--- a/packages/package.json
+++ b/packages/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "@types/base-64": "^1.0.0"
+  }
+}


### PR DESCRIPTION
Using atob is now deprecated. This change also ensures this package can be used within React Native.