### PR TITLE
Upgrade data-sdk realtime-sdk to 1.0.0

### DIFF
--- a/packages/data-sdk/package.json
+++ b/packages/data-sdk/package.json
@@ -46,7 +46,7 @@
     "docs": "typedoc src/main.ts --theme default --out ../../docs/data-sdk/"
   },
   "devDependencies": {
-    "@formant/realtime-sdk": "0.0.20",
+    "@formant/realtime-sdk": "1.0.0",
     "@types/base-64": "^1.0.0",
     "@types/node": "^18.16.3",
     "@types/pako": "^2.0.0",


### PR DESCRIPTION
realtime-sdk 1.0.0 includes a fix to reduce ICE gathering max time to 3 seconds. The current release of the realtime video module will fail after 15 seconds (ICE gathering completes immediately after this timeout).