### PR TITLE
Add HEADLESS teleop session type

### DIFF
--- a/packages/data-sdk/src/model/SessionType.ts
+++ b/packages/data-sdk/src/model/SessionType.ts
@@ -7,6 +7,7 @@ export const SessionTypes = {
   TELEOP: 1,
   PORT_FORWARD: 2,
   OBSERVE: 3,
+  HEADLESS: 4,
 } as const satisfies Record<string, SessionType>;
 
 // For backwards-compatibility
@@ -17,9 +18,11 @@ export const SessionTypeConstants = {
   Teleop: SessionTypes.TELEOP,
   PortForward: SessionTypes.PORT_FORWARD,
   Observe: SessionTypes.OBSERVE,
+  Headless: SessionTypes.HEADLESS,
 
   unknown: SessionTypes.UNKNOWN,
   teleop: SessionTypes.TELEOP,
   portForward: SessionTypes.PORT_FORWARD,
   observe: SessionTypes.OBSERVE,
+  headless: SessionTypes.HEADLESS,
 } as const satisfies Record<string, SessionType>;


### PR DESCRIPTION
Has already been implemented in `telemetry`. This will be the new session type used for components such as the terminal, which should not activate the camera.