### PR TITLE
Task/jh/realtime sdk bump

### DIFF
--- a/packages/data-sdk/package-lock.json
+++ b/packages/data-sdk/package-lock.json
@@ -16,7 +16,7 @@
         "pako": "^2.1.0"
       },
       "devDependencies": {
-        "@formant/realtime-sdk": "1.0.0",
+        "@formant/realtime-sdk": "1.1.0",
         "@types/base-64": "^1.0.0",
         "@types/node": "^18.16.3",
         "@types/pako": "^2.0.0",
@@ -72,14 +72,13 @@
       }
     },
     "node_modules/@formant/realtime-sdk": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@formant/realtime-sdk/-/realtime-sdk-1.0.0.tgz",
-      "integrity": "sha512-dYEWKwVdDIfMYGZPmQ1kg/PtSJCZR41c1IOWPrGEKdWk4KV16Wn2lGWHIRXdqd2MRU9e0HEFP+D9bOZjBxa4KA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@formant/realtime-sdk/-/realtime-sdk-1.1.0.tgz",
+      "integrity": "sha512-fle6ivyioJoL7eNzI3lsWCPWtA2LCJ1zLgN6nIR0ZUCtucGSNwi7GKijKA+g0tlxeo33Yp7kTaODL2q46wJN9w==",
       "dev": true,
       "dependencies": {
         "@types/google-protobuf": "~3.7.0",
-        "env-var": "^7.3.1",
-        "grpc-web": "^1.2.1"
+        "env-var": "^7.3.1"
       }
     },
     "node_modules/@istanbuljs/schema": {
@@ -2394,14 +2393,13 @@
       "optional": true
     },
     "@formant/realtime-sdk": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@formant/realtime-sdk/-/realtime-sdk-1.0.0.tgz",
-      "integrity": "sha512-dYEWKwVdDIfMYGZPmQ1kg/PtSJCZR41c1IOWPrGEKdWk4KV16Wn2lGWHIRXdqd2MRU9e0HEFP+D9bOZjBxa4KA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@formant/realtime-sdk/-/realtime-sdk-1.1.0.tgz",
+      "integrity": "sha512-fle6ivyioJoL7eNzI3lsWCPWtA2LCJ1zLgN6nIR0ZUCtucGSNwi7GKijKA+g0tlxeo33Yp7kTaODL2q46wJN9w==",
       "dev": true,
       "requires": {
         "@types/google-protobuf": "~3.7.0",
-        "env-var": "^7.3.1",
-        "grpc-web": "^1.2.1"
+        "env-var": "^7.3.1"
       }
     },
     "@istanbuljs/schema": {

--- a/packages/data-sdk/package-lock.json
+++ b/packages/data-sdk/package-lock.json
@@ -16,7 +16,7 @@
         "pako": "^2.1.0"
       },
       "devDependencies": {
-        "@formant/realtime-sdk": "1.1.0",
+        "@formant/realtime-sdk": "1.2.0",
         "@types/base-64": "^1.0.0",
         "@types/node": "^18.16.3",
         "@types/pako": "^2.0.0",
@@ -34,7 +34,7 @@
         "node": "^18.12.0 || ^16.13.0"
       },
       "peerDependencies": {
-        "@formant/realtime-sdk": "^0.0.20 || ^1.0.0"
+        "@formant/realtime-sdk": "^1.2.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -72,9 +72,9 @@
       }
     },
     "node_modules/@formant/realtime-sdk": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@formant/realtime-sdk/-/realtime-sdk-1.1.0.tgz",
-      "integrity": "sha512-fle6ivyioJoL7eNzI3lsWCPWtA2LCJ1zLgN6nIR0ZUCtucGSNwi7GKijKA+g0tlxeo33Yp7kTaODL2q46wJN9w==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@formant/realtime-sdk/-/realtime-sdk-1.2.0.tgz",
+      "integrity": "sha512-BOzD40kjGHyHLYhwna/FPTMItnrkIaLvALWh/iM6M7/22ZpDJWLqdtrC7GK80B04KvllQHrkCQGUgQmu2aDXfg==",
       "dev": true,
       "dependencies": {
         "@types/google-protobuf": "~3.7.0",
@@ -2393,9 +2393,9 @@
       "optional": true
     },
     "@formant/realtime-sdk": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@formant/realtime-sdk/-/realtime-sdk-1.1.0.tgz",
-      "integrity": "sha512-fle6ivyioJoL7eNzI3lsWCPWtA2LCJ1zLgN6nIR0ZUCtucGSNwi7GKijKA+g0tlxeo33Yp7kTaODL2q46wJN9w==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@formant/realtime-sdk/-/realtime-sdk-1.2.0.tgz",
+      "integrity": "sha512-BOzD40kjGHyHLYhwna/FPTMItnrkIaLvALWh/iM6M7/22ZpDJWLqdtrC7GK80B04KvllQHrkCQGUgQmu2aDXfg==",
       "dev": true,
       "requires": {
         "@types/google-protobuf": "~3.7.0",

--- a/packages/data-sdk/package.json
+++ b/packages/data-sdk/package.json
@@ -46,7 +46,7 @@
     "docs": "typedoc src/main.ts --theme default --out ../../docs/data-sdk/"
   },
   "devDependencies": {
-    "@formant/realtime-sdk": "1.1.0",
+    "@formant/realtime-sdk": "1.2.0",
     "@types/base-64": "^1.0.0",
     "@types/node": "^18.16.3",
     "@types/pako": "^2.0.0",
@@ -69,7 +69,7 @@
     "pako": "^2.1.0"
   },
   "peerDependencies": {
-    "@formant/realtime-sdk": "^1.1.0"
+    "@formant/realtime-sdk": "^1.2.0"
   },
   "engines": {
     "node": "^18.12.0 || ^16.13.0"

--- a/packages/data-sdk/package.json
+++ b/packages/data-sdk/package.json
@@ -46,7 +46,7 @@
     "docs": "typedoc src/main.ts --theme default --out ../../docs/data-sdk/"
   },
   "devDependencies": {
-    "@formant/realtime-sdk": "1.0.0",
+    "@formant/realtime-sdk": "1.1.0",
     "@types/base-64": "^1.0.0",
     "@types/node": "^18.16.3",
     "@types/pako": "^2.0.0",
@@ -69,7 +69,7 @@
     "pako": "^2.1.0"
   },
   "peerDependencies": {
-    "@formant/realtime-sdk": "^0.0.20 || ^1.0.0"
+    "@formant/realtime-sdk": "^1.1.0"
   },
   "engines": {
     "node": "^18.12.0 || ^16.13.0"

--- a/packages/data-sdk/src/AppRtcClientPools.ts
+++ b/packages/data-sdk/src/AppRtcClientPools.ts
@@ -50,6 +50,16 @@ const EnumRtcClientPools = {
         receive: receiveFn,
       }),
   }),
+  [SessionTypes.HEADLESS]: new RtcClientPool({
+    ttlMs: 2_500,
+    createClient: (receiveFn) =>
+      new RtcClient({
+        signalingClient: new SignalingPromiseClient(FORMANT_API_URL),
+        getToken,
+        sessionType: SessionTypes.HEADLESS,
+        receive: receiveFn,
+      }),
+  }),
 } as const;
 
 export const AppRtcClientPools = {
@@ -58,6 +68,7 @@ export const AppRtcClientPools = {
   teleop: EnumRtcClientPools[SessionTypes.TELEOP],
   portForward: EnumRtcClientPools[SessionTypes.PORT_FORWARD],
   observe: EnumRtcClientPools[SessionTypes.OBSERVE],
+  headless: EnumRtcClientPools[SessionTypes.HEADLESS],
 } as const;
 
 export const defaultRtcClientPool = EnumRtcClientPools[SessionTypes.TELEOP];

--- a/packages/data-sdk/src/api/getPeers.ts
+++ b/packages/data-sdk/src/api/getPeers.ts
@@ -1,4 +1,4 @@
-import { IRtcPeer } from "@formant/realtime-sdk/dist/model/IRtcPeer";
+import { IRtcPeer } from "@formant/realtime-sdk";
 
 import { Authentication } from "../Authentication";
 import { defaultRtcClientPool } from "../AppRtcClientPools";

--- a/packages/data-sdk/src/devices/BaseDevice.ts
+++ b/packages/data-sdk/src/devices/BaseDevice.ts
@@ -2,6 +2,7 @@ import {
   IRtcSendConfiguration,
   IRtcStreamMessage,
   RtcClient,
+  IRtcPeer,
 } from "@formant/realtime-sdk";
 import { DataChannel } from "../DataChannel";
 import { EventEmitter } from "eventemitter3";
@@ -11,7 +12,6 @@ import {
   TextRequestDataChannel,
 } from "../RequestDataChannel";
 import { defined } from "../../../common/defined";
-import { IRtcPeer } from "@formant/realtime-sdk/dist/model/IRtcPeer";
 import { IRealtimeSubscriber } from "./IRealtimeSubscriber";
 import { ICustomDataChannelCreator } from "./ICustomDataChannelCreator";
 import {

--- a/packages/data-sdk/src/devices/Device.ts
+++ b/packages/data-sdk/src/devices/Device.ts
@@ -1,5 +1,4 @@
-import { RtcClient } from "@formant/realtime-sdk";
-import { IRtcPeer } from "@formant/realtime-sdk/dist/model/IRtcPeer";
+import { RtcClient, IRtcPeer } from "@formant/realtime-sdk";
 import { getRtcClientPool } from "../AppRtcClientPools";
 import { Authentication } from "../Authentication";
 import { CaptureStream } from "../CaptureStream";

--- a/packages/data-sdk/src/devices/PeerDevice.ts
+++ b/packages/data-sdk/src/devices/PeerDevice.ts
@@ -1,7 +1,6 @@
-import { RtcClient } from "@formant/realtime-sdk";
+import { RtcClient, IRtcPeer } from "@formant/realtime-sdk";
 import { delay } from "../../../common/delay";
 import { IStreamCurrentValue } from "../model/IStreamCurrentValue";
-import { IRtcPeer } from "@formant/realtime-sdk/dist/model/IRtcPeer";
 import { ConfigurationDocument } from "./device.types";
 import { BaseDevice } from "./BaseDevice";
 

--- a/packages/data-sdk/src/devices/device.types.ts
+++ b/packages/data-sdk/src/devices/device.types.ts
@@ -1,8 +1,7 @@
-import { IRtcStreamPayload } from "@formant/realtime-sdk";
+import { IRtcStreamPayload, RtcStreamType } from "@formant/realtime-sdk";
 import { ITags } from "../model/ITags";
 import { Uuid } from "../model/Uuid";
 import { SessionType } from "../model/SessionType";
-import { RtcStreamType } from "@formant/realtime-sdk/dist/model/RtcStreamType";
 
 export interface ConfigurationDocument {
   tags: ITags;

--- a/packages/data-sdk/src/utils/isRtcPeer.ts
+++ b/packages/data-sdk/src/utils/isRtcPeer.ts
@@ -1,4 +1,4 @@
-import { IRtcPeer } from "@formant/realtime-sdk/dist/model/IRtcPeer";
+import { IRtcPeer } from "@formant/realtime-sdk";
 
 export const isRtcPeer = (peer: IRtcPeer | undefined): peer is IRtcPeer =>
   peer !== undefined &&


### PR DESCRIPTION
- bump `@formant/realtime-sdk` to `1.2.0`
- expose `HEADLESS` RtcClientPool
- use better/cleaner type exports from `@formant/realtime-sdk`, rather than peeking at package internals.