### PR TITLE
Fix for missing orgId

### DIFF
--- a/packages/data-sdk/src/api/getDevices.ts
+++ b/packages/data-sdk/src/api/getDevices.ts
@@ -1,6 +1,7 @@
 import { Device } from "../devices/Device";
 import { Authentication } from "../Authentication";
 import { FORMANT_API_URL } from "../config";
+import { defined } from "../../../common/defined";
 
 export async function getDevices(): Promise<Device[]> {
   if (!Authentication.token) {
@@ -21,7 +22,7 @@ export async function getDevices(): Promise<Device[]> {
       new Device(
         _.id as string,
         _.name as string,
-        _.organizationId as string,
+        defined(Authentication.currentOrganization) as string,
         _.tags
       )
   );


### PR DESCRIPTION
Note that `/admin/device-details/query` does not return organizationId in the payload. This change will grab the organizationId similarly to how we do it elsewhere in data-sdk.