### PR TITLE
Revert / Fix Worker imports (were hidden in RT)

### DIFF
--- a/packages/data-sdk/src/connector/data/BaseUniverseDataConnector.ts
+++ b/packages/data-sdk/src/connector/data/BaseUniverseDataConnector.ts
@@ -1,5 +1,16 @@
 import { subDays } from "date-fns";
+// @ts-ignore
+// eslint-disable-next-line import/no-unresolved
+import RealtimePlayerWorker from "../../node_modules/@formant/ui-sdk-realtime-player-core-worker/dist/ui-sdk-realtime-player-core-worker.umd?worker&inline";
+// eslint-disable-next-line import/no-unresolved
+// @ts-ignore-next-line
+import PcdWorker from "./PcdLoaderWorker?worker&inline";
+// @ts-ignore-next-line
+import DataFetchWorker from "./DataFetchWorker?worker&inline";
 import { H264BytestreamCanvasDrawer } from "@formant/ui-sdk-realtime-player-core";
+// @ts-ignore
+// eslint-disable-next-line import/no-unresolved
+import RealtimePlayerWorker from "../../../node_modules/@formant/ui-sdk-realtime-player-core-worker/dist/ui-sdk-realtime-player-core-worker.umd?worker&inline";
 import {
   CloseSubscription,
   DataSourceState,
@@ -91,15 +102,11 @@ export class BasicUniverseDataConnector {
   constructor() {
     this.time = "live";
     for (let i = 0; i < PCD_WORKER_POOL_SIZE; i++) {
-      const pcdWorker = new Worker(
-        new URL("./PcdLoaderWorker", import.meta.url)
-      );
+      const pcdWorker = new PcdWorker();
       this.pcdWorkerPool.push(pcdWorker);
     }
     for (let i = 0; i < DATA_FETCH_WORKER_POOL_SIZE; i++) {
-      const dataFetchWorker = new Worker(
-        new URL("./DataFetchWorker", import.meta.url)
-      );
+      const dataFetchWorker = new DataFetchWorker();
       this.dataFetchWorkerPool.push(dataFetchWorker);
     }
 
@@ -320,10 +327,7 @@ export class BasicUniverseDataConnector {
 
   protected createH264Drawer(): H264BytestreamCanvasDrawer {
     const drawer = new H264BytestreamCanvasDrawer(
-      () =>
-        new Worker(
-          "@formant/ui-sdk-realtime-player-core-worker/dist/ui-sdk-realtime-player-core-worker"
-        ),
+      () => new RealtimePlayerWorker(),
       () => {},
       () => {}
     );

--- a/packages/three-formant-video/src/DeviceVideo.ts
+++ b/packages/three-formant-video/src/DeviceVideo.ts
@@ -2,6 +2,8 @@ import * as THREE from "three";
 import { Device, RealtimeVideoStream } from "@formant/data-sdk";
 import { defined } from "../../common/defined";
 import { H264BytestreamCanvasDrawer } from "@formant/ui-sdk-realtime-player-core";
+// @ts-ignore
+import RealtimePlayerWorker from "../node_modules/@formant/ui-sdk-realtime-player-core-worker/dist/ui-sdk-realtime-player-core-worker.umd?worker&inline";
 
 export class DeviceVideo extends THREE.Object3D {
   videoStream: RealtimeVideoStream | undefined;
@@ -11,7 +13,7 @@ export class DeviceVideo extends THREE.Object3D {
   constructor(private device: Device, videoStreamName?: string) {
     super();
     this.drawer = new H264BytestreamCanvasDrawer(
-      () => new Worker("@formant/ui-sdk-realtime-player-core-worker/dist/ui-sdk-realtime-player-core-worker"),
+      () => new RealtimePlayerWorker(),
       () => {},
       () => {}
     );

--- a/packages/ui-sdk-realtime-player/src/main.ts
+++ b/packages/ui-sdk-realtime-player/src/main.ts
@@ -1,11 +1,13 @@
 import * as UiCore from "@formant/ui-sdk-realtime-player-core";
+// @ts-ignore
+import RealtimePlayerWorker from "../node_modules/@formant/ui-sdk-realtime-player-core-worker/dist/ui-sdk-realtime-player-core-worker.umd?worker&inline";
 export class RealtimePlayer extends HTMLElement {
   drawer: UiCore.H264BytestreamCanvasDrawer;
 
   constructor() {
     super();
     this.drawer = new UiCore.H264BytestreamCanvasDrawer(
-      () => new Worker("@formant/ui-sdk-realtime-player-core-worker/dist/ui-sdk-realtime-player-core-worker"),
+      () => new RealtimePlayerWorker(),
       () => {},
       () => {}
     );

--- a/packages/universe-connector/src/data/BaseUniverseDataConnector.ts
+++ b/packages/universe-connector/src/data/BaseUniverseDataConnector.ts
@@ -24,8 +24,16 @@ import {
   UniverseDataSource,
 } from "../main";
 import { subDays } from "date-fns";
-
+// @ts-ignore
+// eslint-disable-next-line import/no-unresolved
+import RealtimePlayerWorker from "../../node_modules/@formant/ui-sdk-realtime-player-core-worker/dist/ui-sdk-realtime-player-core-worker.umd?worker&inline";
+// eslint-disable-next-line import/no-unresolved
+// @ts-ignore-next-line
+import PcdWorker from "./PcdLoaderWorker?worker&inline";
 import { H264BytestreamCanvasDrawer } from "@formant/ui-sdk-realtime-player-core";
+// @ts-ignore
+// eslint-disable-next-line import/no-unresolved
+import RealtimePlayerWorker from "../../node_modules/@formant/ui-sdk-realtime-player-core-worker/dist/ui-sdk-realtime-player-core-worker.umd?worker&inline";
 
 export type DeviceId = string;
 export type DataSourceId = string;
@@ -40,7 +48,7 @@ const debug =
   new URLSearchParams(window.location.search).get("debug") === "true";
 
 export class BasicUniverseDataConnector {
-  pcdWorker = new Worker(new URL('./PcdLoaderWorker', import.meta.url));
+  pcdWorker = new PcdWorker();
 
   subscriberSources: Map<string, Map<string, UniverseDataSource>> = new Map();
 
@@ -245,7 +253,7 @@ export class BasicUniverseDataConnector {
 
   protected createH264Drawer(): H264BytestreamCanvasDrawer {
     const drawer = new H264BytestreamCanvasDrawer(
-      () => new Worker("@formant/ui-sdk-realtime-player-core-worker/dist/ui-sdk-realtime-player-core-worker"),
+      () => new RealtimePlayerWorker(),
       () => {},
       () => {}
     );


### PR DESCRIPTION
- [ ] Worker loaders are not working in the frontend, since they are not WP5 yet