### PR TITLE
DEV-8644 - return geometry json when it doesn't come as url asset

### DIFF
--- a/packages/data-sdk/src/connector/data/TelemetryUniverseData.ts
+++ b/packages/data-sdk/src/connector/data/TelemetryUniverseData.ts
@@ -397,7 +397,7 @@ export class TelemetryUniverseData
             dataFetchWorker.onmessage = (
               ev: MessageEvent<{ url: string; response: any }>
             ) => {
-              jsonString = JSON.stringify(ev.data);
+              jsonString = JSON.stringify(ev.data.response);
               callback(JSON.parse(jsonString) as IMarker3DArray);
             };
           } else {

--- a/packages/data-sdk/src/connector/data/TelemetryUniverseData.ts
+++ b/packages/data-sdk/src/connector/data/TelemetryUniverseData.ts
@@ -400,6 +400,8 @@ export class TelemetryUniverseData
               jsonString = JSON.stringify(ev.data);
               callback(JSON.parse(jsonString) as IMarker3DArray);
             };
+          } else {
+            callback(JSON.parse(jsonString) as IMarker3DArray);
           }
         }
       );


### PR DESCRIPTION
Geometry data always came as url asset and it was built expecting that.
That is not the case anymore so this return the json directly.