### PR TITLE
logic bug

### DIFF
--- a/packages/data-sdk/src/connector/data/TelemetryUniverseData.ts
+++ b/packages/data-sdk/src/connector/data/TelemetryUniverseData.ts
@@ -153,7 +153,7 @@ export class TelemetryUniverseData
           const points = streamData.points;
           if (points.length > 0) {
             const lastPoint = points[points.length - 1];
-            if (latestOnly) {
+            if (!latestOnly) {
               let nearestPointTime = lastPoint[0];
               let nearestPoint = lastPoint[1];
               points.forEach((p: any) => {


### PR DESCRIPTION
I noticed a logic bug when looking at old data, telemetry connector is always returning the last datapoint (which can be anywhere to 15 seconds behind to 5 seconds in the future)
![image](https://github.com/FormantIO/toolkit/assets/116584958/d18634ab-91b5-4338-95da-b288ebc2c6d4)
