### PR TITLE
Detect env correctly when hosted in the FE

### DIFF
--- a/packages/data-sdk/src/config/index.ts
+++ b/packages/data-sdk/src/config/index.ts
@@ -6,5 +6,8 @@ export const FORMANT_API_URL = whichFormantApiUrl(
     typeof window !== "undefined" && window.location
       ? window.location.search
       : undefined
-  )
+  ),
+  typeof window !== "undefined" && window.location
+    ? window.location.host
+    : undefined
 );

--- a/packages/data-sdk/src/config/whichFormantApiUrl.ts
+++ b/packages/data-sdk/src/config/whichFormantApiUrl.ts
@@ -5,9 +5,23 @@ interface IHasString {
   has(key: string): boolean;
 }
 
-export function whichFormantApiUrl(global: any, urlParams: IHasString) {
+export function whichFormantApiUrl(
+  global: any,
+  urlParams: IHasString,
+  host?: string
+) {
   // url params may not be available when using react native
   try {
+    if (host) {
+      if (host.includes("app-dev.formant.io") || host.includes("localhost")) {
+        return "https://api-dev.formant.io";
+      } else if (host.includes("app-stage.formant.io")) {
+        return "https://api-stage.formant.io";
+      } else if (host.includes("app.formant.io")) {
+        return "https://api.formant.local";
+      }
+    }
+
     if (urlParams.get("formant_stage")) {
       return "https://api-stage.formant.io";
     }


### PR DESCRIPTION
Currently, data-sdk relies upon search params to detect the environment. This adds support for reading the current host and setting the proper API endpoint appropriately.