### PR TITLE
Allow for bypass of user fetching during auth

### DIFF
--- a/packages/data-sdk/src/stores/AuthenticationStore.ts
+++ b/packages/data-sdk/src/stores/AuthenticationStore.ts
@@ -161,7 +161,11 @@ export class AuthenticationStore implements IAuthenticationStore {
     }
   }
 
-  async loginWithToken(token: string, refreshToken?: string) {
+  async loginWithToken(
+    token: string,
+    refreshToken?: string,
+    skipUserFetch = false
+  ) {
     const tokenData = JSON.parse(decode(token.split(".")[1]));
     try {
       let userId: string | undefined;
@@ -183,7 +187,7 @@ export class AuthenticationStore implements IAuthenticationStore {
         userId = tokenData["formant:claims"].userId;
       }
 
-      if (userId && this._currentUser?.id !== userId) {
+      if (userId && this._currentUser?.id !== userId && !skipUserFetch) {
         const result = await fetch(`${this._apiUrl}/v1/admin/users/${userId}`, {
           method: "GET",
           headers: {


### PR DESCRIPTION
Simple bypass where we may not want to query the BE for the user associated with a token. This seems to be an issue when using service accounts. It appears this user data is only used for sending commands.